### PR TITLE
Attempt to fix broken logo images

### DIFF
--- a/notebooks/01BasicVisualization.ipynb
+++ b/notebooks/01BasicVisualization.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table>\n",
-    "    <tr>\n",
-    "        <td>\n",
-    "          <img src=\"images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"></img>\n",
-    "        </td>\n",
-    "        <td>\n",
-    "          <img src=\"images/ecmwf.png\" style=\"width:250px\" alt=\"ECMWF logo\">\n",
-    "        </td>\n",
-    "        <td>\n",
-    "          <img src=\"images/googleresearch.png\" style=\"width:250px\" alt=\"Google logo\">\n",
-    "        </td>\n",
-    "    </tr>\n",
-    "</table>"
+    "| <img src=\"images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"> | <img src=\"images/ecmwf.png\" style=\"width:250px\" alt=\"ECMWF logo\"> | <img src=\"images/googleresearch.png\" style=\"width:250px\" alt=\"Google logo\"> |"
    ]
   },
   {
@@ -25,6 +13,16 @@
    "source": [
     "# 01_BasicVisualization"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -6293,7 +6291,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.6 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -6307,7 +6305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.6"
   },
   "nbdime-conflicts": {
    "local_diff": [
@@ -6363,7 +6361,12 @@
     }
    ]
   },
-  "toc-autonumbering": false
+  "toc-autonumbering": false,
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/notebooks/02InteractiveVisualization.ipynb
+++ b/notebooks/02InteractiveVisualization.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table>\n",
-    "    <tr>\n",
-    "        <td>\n",
-    "          <img src=\"images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"></img>\n",
-    "        </td>\n",
-    "        <td>\n",
-    "          <img src=\"images/ecmwf.png\" style=\"width:250px\" alt=\"ECMWF logo\">\n",
-    "        </td>\n",
-    "        <td>\n",
-    "          <img src=\"images/googleresearch.png\" style=\"width:250px\" alt=\"Google logo\">\n",
-    "        </td>\n",
-    "    </tr>\n",
-    "</table>"
+    "| <img src=\"images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"> | <img src=\"images/ecmwf.png\" style=\"width:250px\" alt=\"ECMWF logo\"> | <img src=\"images/googleresearch.png\" style=\"width:250px\" alt=\"Google logo\"> |"
    ]
   },
   {
@@ -548,7 +536,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.6 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -562,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.6"
   },
   "nbdime-conflicts": {
    "local_diff": [
@@ -618,7 +606,12 @@
     }
    ]
   },
-  "toc-autonumbering": false
+  "toc-autonumbering": false,
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Currently the logos at the top of the [published notebooks](https://projectpythia.org/ERA5_interactive-cookbook/notebooks/01BasicVisualization.html) are not appearing.

I think the reason is that jupyter-book / myst-nb are not handling the relative path corrections for the html `img` tags because they are wrapped in an html table.

Here I try to replace the html table with a markdown table instead to see if that fixes the problem.

The way [jupyter-book handles html image tags](https://jupyterbook.org/en/stable/content/figures.html#raw-html-images) is a bit confusing. We'll see in the PR preview if this helps.