### PR TITLE
Add cook-off event tags for gallery

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -7,3 +7,6 @@ tags:
     - geoviews
     - panel
     - xarray
+events:
+    - Cook-off 2023
+    - Cook-off 2024

--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -7,6 +7,6 @@ tags:
     - geoviews
     - panel
     - xarray
-events:
+  events:
     - Cook-off 2023
     - Cook-off 2024


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
No effect on the cookbook itself, just on the filterable tags on the Pythia gallery.

I'm including both 2023 and 2024 Cook-off events here since this cookbook saw key updates at both events.